### PR TITLE
Updates build URL

### DIFF
--- a/debian-9.5.0-stretch.json
+++ b/debian-9.5.0-stretch.json
@@ -22,7 +22,7 @@
     "http_directory": "http",
     "iso_checksum": "f8446a84356a6bcbf79201cc9f46063f",
     "iso_checksum_type": "md5",
-    "iso_url": "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-9.5.0-amd64-netinst.iso",
+    "iso_url": "https://cdimage.debian.org/mirror/cdimage/archive/9.5.0/amd64/iso-cd/debian-9.5.0-amd64-netinst.iso",
     "output_directory": "builds/",
     "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
     "ssh_username": "vagrant",

--- a/debian-9.5.0-stretch.json
+++ b/debian-9.5.0-stretch.json
@@ -27,6 +27,7 @@
     "shutdown_command": "echo 'vagrant' | sudo -S shutdown -P now",
     "ssh_username": "vagrant",
     "ssh_password": "vagrant",
+    "ssh_timeout": "10m",
     "type": "virtualbox-iso",
     "vboxmanage": [
       ["modifyvm", "{{ .Name }}", "--memory", "512"],


### PR DESCRIPTION
With the release of Debian 9.6.0, the image for 9.5.0 is now in an archived directory. Also updated the SSH timeout attribute. On a slow connection with no cache, the default SSH wait timeout is not long enough.