### PR TITLE
Add Docker credential pass utility

### DIFF
--- a/debian-9.5.0-stretch.json
+++ b/debian-9.5.0-stretch.json
@@ -32,7 +32,7 @@
       ["modifyvm", "{{ .Name }}", "--memory", "512"],
       ["modifyvm", "{{ .Name }}", "--cpus", "2"]
     ],
-    "vm_name": "debian-9.5"
+    "vm_name": "debian-9.5.0"
   }],
   "description": "Debian 9.5 for Docker 18.06.1-ce base box",
   "post-processors": [
@@ -49,6 +49,7 @@
       "scripts": [
         "scripts/update.sh",
         "scripts/provision.sh",
+        "scripts/docker_credential_pass.sh",
         "scripts/sudoers.sh",
         "scripts/sshd.sh",
         "scripts/vagrant.sh",

--- a/scripts/docker_credential_pass.sh
+++ b/scripts/docker_credential_pass.sh
@@ -1,5 +1,9 @@
 #!/bin/bash --
 
+# Install pass to encrypt docker login information
+# Install haveged to generate sufficient entropy for gpg key creation
+apt-get install pass haveged -y
+
 # Define the vagrant user directory
 VAGRANT_HOME="/home/vagrant"
 
@@ -23,4 +27,3 @@ tar xf docker-credential-pass-v0.6.0-amd64.tar.gz
 
 # Remove downloaded file
 rm *.tar.gz
-

--- a/scripts/docker_credential_pass.sh
+++ b/scripts/docker_credential_pass.sh
@@ -1,0 +1,26 @@
+#!/bin/bash --
+
+# Define the vagrant user directory
+VAGRANT_HOME="/home/vagrant"
+
+# Define the target directory
+TARGET="$VAGRANT_HOME/lib"
+
+# Make the target directory
+mkdir $TARGET
+
+# Update vagrant user PATH with target directory
+echo "export PATH=\"\$PATH:$TARGET\"" >> $VAGRANT_HOME/.bashrc
+
+# Change current working directory to target directory
+cd $TARGET
+
+# Download the docker-credential-pass helper
+curl -O -L https://github.com/docker/docker-credential-helpers/releases/download/v0.6.0/docker-credential-pass-v0.6.0-amd64.tar.gz
+
+# Extract the helper file
+tar xf docker-credential-pass-v0.6.0-amd64.tar.gz
+
+# Remove downloaded file
+rm *.tar.gz
+

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -4,8 +4,7 @@
 apt-get install -y apt-transport-https \
 	ca-certificates \
 	gnupg2 \
-	software-properties-common \
-	pass
+	software-properties-common
 
 # Add Docker GPG key to system
 curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -

--- a/scripts/provision.sh
+++ b/scripts/provision.sh
@@ -4,7 +4,8 @@
 apt-get install -y apt-transport-https \
 	ca-certificates \
 	gnupg2 \
-	software-properties-common
+	software-properties-common \
+	pass
 
 # Add Docker GPG key to system
 curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -


### PR DESCRIPTION
This pull request adds the `docker-credential-pass` helper to encrypt docker credentials locally instead of saving them to `$USER/.docker/config.json` as base64 encoded values.

In order to use this the password store must be initialized using a GPG key.

```
gpg --full-generate-key
```

Follow through the prompts and you should get something like:

```
gpg: revocation certificate stored as '/home/vagrant/.gnupg/openpgp-revocs.d/7F831071AAB85632B8716BD9D648B8718C3E6D30.rev'
public and secret key created and signed.

pub   rsa3072 2018-11-19 [SC]
      7F831071AAB85632B8716BD9D648B8718C3E6D30
      7F831071AAB85632B8716BD9D648B8718C3E6D30
uid                      Joe Blow <joe.blow@example.org>
sub   rsa3072 2018-11-19 [E]
```

Use the `7F831071AAB85632B8716BD9D648B8718C3E6D30` key to create the password store using `pass init 7F831071AAB85632B8716BD9D648B8718C3E6D30`.

Use `docker login` with your Docker username and password and you are good to go.