### PR TITLE
Adds an example env file

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,4 @@
+source .shared_env
+
+VAGRANT_ACCESS_TOKEN="my-super-secret-vagrant-access-token"
+VAGRANT_USERNAME="my-vagrant-username"


### PR DESCRIPTION
This pull request adds a new file called `.env-example` in the root directory of the project.

The `.env-example` file serves as a template if needing to build from another machine.
It's no fun guessing what is in the `.env` file to make the cloud utils file work.